### PR TITLE
Clean up + Split response creation and send + Early error OK + Manage Internal Server Error + max body size check

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -7,10 +7,11 @@ server {
 	server_name toto.42.fr;
 	cgi .php /usr/bin/php-cgi;
 
-	root /mnt/nfs/homes/alefranc/Documents/cursus42/5_webserv/webserv/www/site1;
-	# root /home/alex/Data/Documents/42/Cursus42/5_webserv/webserv/www/site1;
+	# root /mnt/nfs/homes/alefranc/Documents/cursus42/5_webserv/webserv/www/site1;
+	root /home/alex/Data/Documents/42/Cursus42/5_webserv/webserv/www/site1;
 	# root /home/antoine/Documents/42/webserv/www/site1;
-	# error_page 404 404.html;
+	error_page 404 /home/alex/Data/Documents/42/Cursus42/5_webserv/webserv/www/errors/404.html;
+	error_page 501 /home/alex/Data/Documents/42/Cursus42/5_webserv/webserv/www/errors/404.html;
 	
 	location / {
 		methods GET POST;
@@ -30,8 +31,8 @@ server {
 server {
 	listen 127.0.0.1:8081;
 
-	root /mnt/nfs/homes/alefranc/Documents/cursus42/5_webserv/webserv/www/site2;
-	# root /home/alex/Data/Documents/42/Cursus42/5_webserv/webserv/www/site2;
+	# root /mnt/nfs/homes/alefranc/Documents/cursus42/5_webserv/webserv/www/site2;
+	root /home/alex/Data/Documents/42/Cursus42/5_webserv/webserv/www/site2;
 	# root /home/antoine/Documents/42/webserv/www/site2;
 
 	location / {

--- a/src/cgi/CGI.cpp
+++ b/src/cgi/CGI.cpp
@@ -40,7 +40,7 @@ void				CGI::_init_arrays()
 		query_string.erase(query_string.length() - 1);
 	}
 
-	std::cout << "query_string=" << query_string << std::endl;
+	// std::cout << "query_string=" << query_string << std::endl;
 	_env.push_back("QUERY_STRING=" + query_string);
 
 	for (it = _req._headers.begin(); it != _req._headers.end(); ++it)
@@ -50,7 +50,7 @@ void				CGI::_init_arrays()
 		_env.push_back(key_upper + "=" + it->second);
 	}
 
-	display_vector(_env, "_env");
+	// display_vector(_env, "_env");
 
 	_envp = new	char*[_env.size() + 1];
 	for (size_t i = 0; i < _env.size(); ++i)
@@ -120,7 +120,7 @@ void				CGI::_run_cgi()
 		int		nbytes;
 		while ((nbytes = read(pipeout[READ_END], buffer, BUFF_SIZE - 1)) != 0)
 		{
-			std::cout << nbytes << std::endl;
+			// std::cout << nbytes << std::endl;
 			res_d.insert(res_d.end(), buffer, buffer + nbytes);
 		}
 		wait(NULL);

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1,9 +1,10 @@
 #include "client/Client.hpp"
 
-Client::Client(int server_fd, const ServerConfig& config)
+Client::Client(int server_fd, const HTTPConfig& httpconfig, const ServerConfig& config)
 	: fd(-1)
+	, httpconfig(httpconfig)
 	, config(config)
-	, request(config)
+	, request(httpconfig, config)
 	, request_complete(false)
 	, response(request, config)
 {

--- a/src/client/Client.hpp
+++ b/src/client/Client.hpp
@@ -11,6 +11,7 @@
 # include "webserv.hpp"
 # include "request/Request.hpp"
 # include "request/Response.hpp"
+# include "config/HTTPConfig.hpp"
 # include "config/ServerConfig.hpp"
 
 // Purpose: Keep all info relative to a Client
@@ -25,6 +26,7 @@ private: // Disable defaults behaviors
 
 public:
 	int						fd;
+	const HTTPConfig&		httpconfig;
 	const ServerConfig&		config;
 
 	Request		request;
@@ -32,7 +34,7 @@ public:
 	
 	Response	response;
 
-	Client(int server_fd, const ServerConfig& config);
+	Client(int server_fd, const HTTPConfig& httpconfig, const ServerConfig& config);
 	~Client();
 
 	void	parse_request();

--- a/src/client/ClientManager.cpp
+++ b/src/client/ClientManager.cpp
@@ -5,7 +5,8 @@ ClientManager::ClientManager()
 
 ClientManager::~ClientManager()
 {
-	for (std::map<int, Client*>::iterator it = _clients.begin(); it != _clients.end(); it++)
+	std::map<int, Client*>::iterator it;
+	for (it = _clients.begin(); it != _clients.end(); it++)
 	{
 		delete it->second;
 	}
@@ -13,7 +14,7 @@ ClientManager::~ClientManager()
 
 int	ClientManager::create_client(int server_fd, const ServerConfig& config)
 {
-	Client* new_client = new Client(server_fd, config);
+	Client* new_client = new Client(server_fd, config); // can throw
 	_clients[new_client->fd] = new_client;
 
 	return new_client->fd;

--- a/src/client/ClientManager.cpp
+++ b/src/client/ClientManager.cpp
@@ -12,9 +12,9 @@ ClientManager::~ClientManager()
 	}
 }
 
-int	ClientManager::create_client(int server_fd, const ServerConfig& config)
+int	ClientManager::create_client(int server_fd, const HTTPConfig& httpconfig, const ServerConfig& config)
 {
-	Client* new_client = new Client(server_fd, config); // can throw
+	Client* new_client = new Client(server_fd, httpconfig, config); // can throw
 	_clients[new_client->fd] = new_client;
 
 	return new_client->fd;

--- a/src/client/ClientManager.hpp
+++ b/src/client/ClientManager.hpp
@@ -21,7 +21,7 @@ public:
 	ClientManager();
 	~ClientManager();
 
-	int		create_client(int server_fd, const ServerConfig& config);
+	int		create_client(int server_fd, const HTTPConfig& httpconfig, const ServerConfig& config);
 	void	remove_client(int client_fd);
 	Client&	get_client(int client_fd);
 };

--- a/src/config/HTTPConfig.cpp
+++ b/src/config/HTTPConfig.cpp
@@ -12,6 +12,7 @@
 ==============================================================================*/
 
 HTTPConfig::HTTPConfig(const std::string& config_file)
+	: client_max_body_size(-1)
 {
 	std::cout << RED << "[HTTPConfig] Initiate Config" << CRESET << std::endl;
 	std::ifstream		config(config_file.c_str());
@@ -41,6 +42,11 @@ HTTPConfig::~HTTPConfig()
 const std::list<ServerConfig>&	HTTPConfig::get_virtual_server_config() const
 {
 	return (virtual_server_config);
+}
+
+size_t							HTTPConfig::get_max_body_size() const
+{
+	return (client_max_body_size);
 }
 
 /*==============================================================================

--- a/src/config/HTTPConfig.hpp
+++ b/src/config/HTTPConfig.hpp
@@ -16,7 +16,7 @@ private:
 	//	Attributes
 	std::stringstream		content;
 	std::list<ServerConfig>	virtual_server_config;
-	int						client_max_body_size;
+	size_t					client_max_body_size;
 
 	//	Constructors
 	HTTPConfig();
@@ -31,6 +31,7 @@ public:
 	~HTTPConfig();
 	//		Getters
 	const std::list<ServerConfig>&	get_virtual_server_config() const;
+	size_t							get_max_body_size() const;
 
 private:
 	//	parsing functions

--- a/src/core/HTTPServer.cpp
+++ b/src/core/HTTPServer.cpp
@@ -26,7 +26,7 @@ void	HTTPServer::_create_client(int server_fd)
 
 	const	ServerConfig&	config = _server_manager.get_server_config(server_fd);
 
-	int client_fd = _client_manager.create_client(server_fd, config); // can throw
+	int client_fd = _client_manager.create_client(server_fd, _config, config); // can throw
 	_fds[client_fd] = "CLIENT";
 	_epoll.add_fd(client_fd, EPOLLIN | EPOLLOUT | EPOLLRDHUP | EPOLLET);
 }
@@ -102,10 +102,10 @@ void	HTTPServer::_internal_server_error(const struct epoll_event& event)
 	
 		if ((event.events & EPOLLOUT) != 0)
 			_client_manager.get_client(event.data.fd).send_response();
-
-		_remove_client(event.data.fd);
 	}
 	catch (...) {} // swallow exception for resilience
+
+	_remove_client(event.data.fd);
 }
 
 /*******************************************************************************

--- a/src/core/HTTPServer.hpp
+++ b/src/core/HTTPServer.hpp
@@ -41,6 +41,7 @@ private:
 	void	_remove_client(int fd);
 
 	int		_communicate_with_client(const struct epoll_event& event);
+	void	_internal_server_error(const struct epoll_event& event);
 
 public:
 	HTTPServer(const std::string& confg_file);

--- a/src/request/Request.hpp
+++ b/src/request/Request.hpp
@@ -10,6 +10,7 @@
 
 # include "webserv.hpp"
 # include "utils/Exceptions.hpp"
+# include "config/HTTPConfig.hpp"
 # include "config/ServerConfig.hpp"
 # include "request/ResponseGenerator.hpp"
 
@@ -21,6 +22,7 @@ private: // Disable defaults behaviors
 	Request&	operator=(const Request& src);
 
 private:
+	const HTTPConfig&					_httpconfig;
 	const ServerConfig&					_config;
 	int									_client_fd;
 
@@ -59,7 +61,7 @@ private:
 	bool	_process_body_chunk();
 
 public:
-	Request(const ServerConfig& config);
+	Request(const HTTPConfig& httpconfig, const ServerConfig& config);
 	~Request();
 
 	void	set_client_fd(int client_fd);

--- a/src/request/Response.cpp
+++ b/src/request/Response.cpp
@@ -35,6 +35,7 @@ const Status Status::BadRequest = Status(400, "Bad Request");
 const Status Status::Forbidden = Status(403, "Not Allowed");
 const Status Status::NotFound = Status(404, "Not Found");
 const Status Status::MethodNotAllowed = Status(405, "Method Not Allowed");
+const Status Status::ContentTooLarge = Status(413, "Content Too Large");
 const Status Status::InternalServerError = Status(500, "Internal Server Error");
 const Status Status::NotImplemented = Status(501, "Not Implemented");
 const Status Status::HTTPVersionNotSupported = Status(505, "HTTP Version Not Supported");
@@ -104,6 +105,8 @@ void	Response::create_error(int status_code)
 {
 	if (status_code == 400)
 		response_status = Status::BadRequest;
+	else if (status_code == 413)
+		response_status = Status::ContentTooLarge;
 	else if (status_code == 500)
 		response_status = Status::InternalServerError;
 	else if (status_code == 501)

--- a/src/request/Response.cpp
+++ b/src/request/Response.cpp
@@ -285,7 +285,7 @@ std::string	Response::_get_filename() const
 		throw (ResponseException());
 	str_body = str_body.substr(boundary.length() + 3);
 	pos_filename = str_body.find("filename=\"") + 10;
-	if (pos_filename < 0)
+	if (pos_filename == std::string::npos)
 		throw (ResponseException());
 	filename_length = str_body.find("\"", pos_filename + 1) - pos_filename;
 	return (str_body.substr(pos_filename, filename_length));

--- a/src/request/Response.cpp
+++ b/src/request/Response.cpp
@@ -168,7 +168,7 @@ void	Response::_serve_get(std::string& target)
 	{
 		std::cout << "Directory with autoindex" << std::endl;
 		body = HTMLGenerator::dirlist(target, request.get_target());
-		std::cout << "Body :" << std::string(body.begin(), body.end()) << std::endl;
+		// std::cout << "Body :" << std::string(body.begin(), body.end()) << std::endl;
 		_add_header("Content-Length", itos(body.size()));
 		response_status = Status::OK;
 		return ;

--- a/src/request/Response.hpp
+++ b/src/request/Response.hpp
@@ -76,7 +76,6 @@ public:
 	const std::vector<char>&	get_body() const;
 	//	Build reponse
 	std::vector<char>			build_response_vector() const;
-	std::vector<char>			build_error_response_vector() const;
 
 private:
 	void				_serve(std::string& target);

--- a/src/request/Response.hpp
+++ b/src/request/Response.hpp
@@ -41,6 +41,7 @@ struct Status
 	static const Status	Forbidden;
 	static const Status	NotFound;
 	static const Status	MethodNotAllowed;
+	static const Status	ContentTooLarge;
 	static const Status	InternalServerError;
 	static const Status	NotImplemented;
 	static const Status	HTTPVersionNotSupported;

--- a/src/utils/Exceptions.cpp
+++ b/src/utils/Exceptions.cpp
@@ -24,3 +24,12 @@ const char* ResponseException::what() const throw()
 {
 	return "ResponseException";
 }
+
+RequestParsingException::RequestParsingException(int code)
+	: code(code)
+{}
+
+const char*	RequestParsingException::what() const throw()
+{
+	return "RequestParsingException";
+}

--- a/src/utils/Exceptions.hpp
+++ b/src/utils/Exceptions.hpp
@@ -2,6 +2,7 @@
 # define EXCEPTIONS_HPP
 
 # include <exception>
+# include <string>
 
 class RecvException: public std::exception
 {
@@ -27,6 +28,14 @@ public:
 class ResponseException: public std::exception
 {
 public:
+	virtual const char*	what() const throw();
+};
+
+class RequestParsingException: public std::exception
+{
+public:
+	int code;
+	RequestParsingException(int code);
 	virtual const char*	what() const throw();
 };
 


### PR DESCRIPTION
- Commenting out some verbose debug
- Separate response creation and response sending in HTTPServer
- Errors during request parsing now give the good error page
- Any exception uncaught in `_communicate_with_client()` send a Internal Server Error and dont crash
- Add check for max_body_size during request parsing and give the correct error